### PR TITLE
added "perms" flag

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,7 +33,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     node.vm.synced_folder "/Users", "/Users.tmp", type: "nfs"
     node.bindfs.bind_folder "/Users.tmp", "/Users",
-      create_as_user: true
+      create_as_user: true,
+      perms: "u=u:g=g:o=o"
 
     node.vm.provision "ansible" do |ansible|
       ansible.playbook = "provisioning/ansible/container_host.yml"


### PR DESCRIPTION
Added the "perms" flag to the bindfs mount so that the permissions from the host are not only used, but **shown** within the VM (e.g. when doing a `ls -la` command). PHP (and surely other things as well) check these permissions to see if the directory/file is writeable ([is_writable()](http://php.net/manual/en/function.is-writable.php)) or not. If it **doesn't** appear writeable, PHP will error out (even if it actually is).
